### PR TITLE
Add bookshelf as a required dependency in the mods.toml

### DIFF
--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -15,3 +15,9 @@ authors = "${mod_author}"
 description = '''
 ${mod_description}
 '''
+[[dependencies.herdmentality]]
+modId = "bookshelf" #mandatory
+mandatory = true #mandatory
+versionRange = "[20.0.1,)" #mandatory
+ordering = "NONE" # The order that this dependency should load in relation to your mod, required to be either 'BEFORE' or 'AFTER' if the dependency is not mandatory
+side = "SERVER" # Side this dependency is applied on - 'BOTH', 'CLIENT' or 'SERVER'

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -20,4 +20,4 @@ modId = "bookshelf" #mandatory
 mandatory = true #mandatory
 versionRange = "[20.0.1,)" #mandatory
 ordering = "NONE" # The order that this dependency should load in relation to your mod, required to be either 'BEFORE' or 'AFTER' if the dependency is not mandatory
-side = "SERVER" # Side this dependency is applied on - 'BOTH', 'CLIENT' or 'SERVER'
+side = "BOTH" # Side this dependency is applied on - 'BOTH', 'CLIENT' or 'SERVER'


### PR DESCRIPTION
This stops the mod from crashing with a NoClassDefFoundError in the event bookshelf is not installed.
